### PR TITLE
Fix vue-i18n example in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -187,7 +187,7 @@ mix.translations();
 Notice you can directly pass the `languageBundle` object as a parameter into the `VueI18n` constructor.
 
 ```js
-import languageBundle from '@kirschbaum-development/laravel-translations-loader!@kirschbaum-development/laravel-translations-loader';
+import languageBundle from '@kirschbaum-development/laravel-translations-loader?parameters={$1}!@kirschbaum-development/laravel-translations-loader';
 import VueI18n from 'vue-i18n';
 Vue.use(VueI18n);
 


### PR DESCRIPTION
vue-i18n is using a different syntax for the translation params than Laravel: `Hello {name}` instead of `Hello :name`
The readme example for vue-i18n is just using the translation-loader without the parameters option.

https://kazupon.github.io/vue-i18n/guide/formatting.html#named-formatting