### PR TITLE
Enable auto-reloading in watch mode when translations change

### DIFF
--- a/all.js
+++ b/all.js
@@ -21,8 +21,8 @@ module.exports = function (indexContent) {
 
     this.addDependency(baseDirectory);
 
-    const jsonContents = jsonLoader.execute(baseDirectory, options);
-    const phpContents = phpLoader.execute(baseDirectory, options);
+    const jsonContents = jsonLoader.execute(baseDirectory, options, this);
+    const phpContents = phpLoader.execute(baseDirectory, options, this);
     const bundle = _.merge(phpContents, jsonContents);
 
     return "module.exports = " + JSON.stringify(bundle);

--- a/json-loader.js
+++ b/json-loader.js
@@ -2,7 +2,7 @@ let fs = require('fs');
 let path = require('path');
 
 const jsonLoader = {
-    execute(baseDirectory, options) {
+    execute(baseDirectory, options, loader) {
         let bundle = {};
 
         files = fs.readdirSync(baseDirectory).filter((file) => {
@@ -11,7 +11,9 @@ const jsonLoader = {
 
         files.forEach((file) => {
             var lang = file.replace('.json', '');
-            var content = fs.readFileSync(path.join(baseDirectory, file));
+            var filePath = path.join(baseDirectory, file);
+            loader.addDependency(filePath);
+            var content = fs.readFileSync(filePath);
 
             if (typeof options.namespace !== 'undefined') {
                 bundle[lang] = {};

--- a/json.js
+++ b/json.js
@@ -21,6 +21,6 @@ module.exports = function (indexContent) {
     this.addDependency(baseDirectory);
 
     return "module.exports = " + JSON.stringify(
-        jsonLoader.execute(baseDirectory, options)
+        jsonLoader.execute(baseDirectory, options, this)
     );
 }

--- a/php-loader.js
+++ b/php-loader.js
@@ -6,7 +6,7 @@ const phpArrayParser = require('php-array-parser');
 const klaw = require('klaw-sync');
 
 const phpLoader = {
-    execute (baseDirectory, options) {
+    execute (baseDirectory, options, loader) {
         var bundle = {};
         var directories;
 
@@ -28,7 +28,9 @@ const phpLoader = {
             }).forEach((file) => {
                 var filename = file.path.split(langDirectory + path.sep)[1];
                 var filename = filename.replace('\\', '/');
-                var content = fs.readFileSync(path.join(langDirectory, filename), 'utf8');
+                var filePath = path.join(langDirectory, filename);
+                loader.addDependency(filePath);
+                var content = fs.readFileSync(filePath, 'utf8');
 
                 // Remove left part of return expression and any ending `?>`.
                 const ret = content.indexOf('return') + 'return'.length

--- a/php.js
+++ b/php.js
@@ -22,6 +22,6 @@ module.exports = function (indexContent) {
     this.addDependency(baseDirectory);
 
     return "module.exports = " + JSON.stringify(
-        phpLoader.execute(baseDirectory, options)
+        phpLoader.execute(baseDirectory, options, this)
     );
 }

--- a/test/php.test.js
+++ b/test/php.test.js
@@ -105,4 +105,15 @@ describe('it should load php language files', function () {
             }
         });
     });
+
+    it('should register translation files as dependencies for live reloading', function () {
+        let dependency;
+        const loaderMock = { addDependency: (dep) => {
+                dependency = dep;
+            } };
+
+        phpLoader.execute('./test/fixtures/php-with-namespace', {}, loaderMock);
+
+        assert.match(dependency, /\/test\/fixtures\/php-with-namespace\/en\/validation\.php$/)
+    });
 });

--- a/test/php.test.js
+++ b/test/php.test.js
@@ -114,6 +114,7 @@ describe('it should load php language files', function () {
 
         phpLoader.execute('./test/fixtures/php-with-namespace', {}, loaderMock);
 
-        assert.match(dependency, /\/test\/fixtures\/php-with-namespace\/en\/validation\.php$/)
+        const expected = '/test/fixtures/php-with-namespace/en/validation.php';
+        assert.strictEqual(dependency.endsWith(expected), true);
     });
 });

--- a/test/php.test.js
+++ b/test/php.test.js
@@ -107,7 +107,7 @@ describe('it should load php language files', function () {
     });
 
     it('should register translation files as dependencies for live reloading', function () {
-        let dependency;
+        let dependency = '';
         const loaderMock = { addDependency: (dep) => {
                 dependency = dep;
             } };
@@ -115,6 +115,7 @@ describe('it should load php language files', function () {
         phpLoader.execute('./test/fixtures/php-with-namespace', {}, loaderMock);
 
         const expected = '/test/fixtures/php-with-namespace/en/validation.php';
-        assert.strictEqual(dependency.endsWith(expected), true);
+        const actual = dependency.substring(dependency.length - expected.length);
+        assert.deepStrictEqual(actual.split(path.sep), expected.split('/'));
     });
 });

--- a/test/php.test.js
+++ b/test/php.test.js
@@ -3,8 +3,10 @@ let path = require('path')
 let phpLoader = require('./../php-loader')
 
 describe('it should load php language files', function () {
+    const loaderMock = { addDependency: () => {} };
+
     it('should load regular php translation', function () {
-        let content = phpLoader.execute('./test/fixtures/php', {});
+        let content = phpLoader.execute('./test/fixtures/php', {}, loaderMock);
 
         assert.deepEqual(content.en, {
             translation: {
@@ -17,7 +19,7 @@ describe('it should load php language files', function () {
     });
 
     it('should load both languages', function () {
-        let content = phpLoader.execute('./test/fixtures/php', {});
+        let content = phpLoader.execute('./test/fixtures/php', {}, loaderMock);
 
         assert.deepEqual(content.en, {
             translation: {
@@ -41,7 +43,7 @@ describe('it should load php language files', function () {
     it('should be able to replace parameters', function () {
         let content = phpLoader.execute('./test/fixtures/php-with-parameters', {
             parameters: '{{ $1 }}'
-        });
+        }, loaderMock);
 
         assert.deepEqual(content.en, {
             validation: {
@@ -51,7 +53,7 @@ describe('it should load php language files', function () {
     });
 
     it('should be able to load nested folders', function () {
-        let content = phpLoader.execute('./test/fixtures/php-with-nested-folders', {});
+        let content = phpLoader.execute('./test/fixtures/php-with-nested-folders', {}, loaderMock);
 
         assert.deepEqual(content.en, {
             validation: {
@@ -68,7 +70,7 @@ describe('it should load php language files', function () {
         let namespace = 'test';
         let content = phpLoader.execute('./test/fixtures/php-with-namespace', {
             namespace: namespace,
-        });
+        }, loaderMock);
 
         assert.deepEqual(content.en[namespace], {
             validation: {
@@ -82,7 +84,7 @@ describe('it should load php language files', function () {
         let content = phpLoader.execute('./test/fixtures/php-with-namespace-parameters', {
             namespace: namespace,
             parameters: '{{ $1 }}'
-        });
+        }, loaderMock);
 
         assert.deepEqual(content.en[namespace], {
             validation: {
@@ -92,7 +94,7 @@ describe('it should load php language files', function () {
     });
 
     it('should not fail execution with invalid file', function () {
-        let content = phpLoader.execute('./test/fixtures/php-with-one-invalid-file', {});
+        let content = phpLoader.execute('./test/fixtures/php-with-one-invalid-file', {}, loaderMock);
 
         assert.deepEqual(content.en, {
             translation: {


### PR DESCRIPTION
The loaders already call addDependency with the directory as the argument, but the Webpack documentation states that it should be a filename. So by passing each detected file to addDependency individually, we gain automatic reloading for the most common case of an existing translation file changing.

Fixes https://github.com/kirschbaum-development/laravel-translations-loader/issues/21
Fixes https://github.com/kirschbaum-development/laravel-translations-loader/issues/6