### PR TITLE
Fix #22 - Better support for vendor based .php files.

### DIFF
--- a/php-loader.js
+++ b/php-loader.js
@@ -46,6 +46,15 @@ const phpLoader = {
                 content = content.replace(/\?>\s*$/, '_')
 
                 let langObject = {}
+                
+                let locale = directory;
+                
+                if (directory === 'vendor') {
+                    const regex = /(^.+?)(\/.+?\/)/g;
+                    locale = [...filename.matchAll(regex)];
+                    locale = locale[0][2].replaceAll("/", "");
+                    filename = filename.replace(regex, "$1/");
+                }
 
                 try {
                     let parsedContent = phpArrayParser.parse(content);
@@ -55,25 +64,25 @@ const phpLoader = {
                 }
 
                 if (typeof options.namespace !== 'undefined') {
-                    if (typeof bundle[directory] === 'undefined') {
-                        bundle[directory] = {};
-                        bundle[directory][options.namespace] = langObject
+                    if (typeof bundle[locale] === 'undefined') {
+                        bundle[locale] = {};
+                        bundle[locale][options.namespace] = langObject
                     } else {
-                        bundle[directory][options.namespace] = _.extend(bundle[directory][options.namespace], langObject);
+                        bundle[locale][options.namespace] = _.extend(bundle[locale][options.namespace], langObject);
                     }
 
                     if (typeof options.parameters !== "undefined") {
-                        bundle[directory][options.namespace] = this.replaceParameter(bundle[directory][options.namespace], options.parameters);
+                        bundle[locale][options.namespace] = this.replaceParameter(bundle[locale][options.namespace], options.parameters);
                     }
                 } else {
-                    if (typeof bundle[directory] === 'undefined') {
-                        bundle[directory] = langObject;
+                    if (typeof bundle[locale] === 'undefined') {
+                        bundle[locale] = langObject;
                     } else {
-                        bundle[directory] = _.extend(bundle[directory], langObject);
+                        bundle[locale] = _.extend(bundle[locale], langObject);
                     }
 
                     if (typeof options.parameters !== "undefined") {
-                        bundle[directory] = this.replaceParameter(bundle[directory], options.parameters);
+                        bundle[locale] = this.replaceParameter(bundle[locale], options.parameters);
                     }
                 }
             });


### PR DESCRIPTION
Fixing issue #22:

1. Determine if we're in the `vendor` folder.
2. Use regex to search for the format `/vendor/{package}/{locale}/filename.php`
3. Use the `locale` as the new "directory" name (N.B. renamed `bundle[directory]` to `bundle[locale]`)
4. Remove the `locale` from the filename.

This will convert the following: `vendor/some-package/en-GB/filename.php` to this:
```
{
    en-GB : {
        some-package/filename: {
            ...
       }
   }
}
```

I don't use the `.json` option, so not sure if this has the same problem with the vendor packages.

I haven't written a new test case for this, but can do if it's required.

I'm not sure if this is classified as a breaking change, as it fixes something that wouldn't have been possible to access previously.

Any questions, just let me know.