### PR TITLE
Bug: use getOptions instead of parseQuery for handling options object

### DIFF
--- a/all.js
+++ b/all.js
@@ -11,7 +11,7 @@ module.exports = function (indexContent) {
     let loaderPath = 'node_modules' + path.sep + '@kirschbaum-development' + path.sep + 'laravel-translations-loader' + path.sep + 'all.js';
 
     try {
-        options = loaderUtils.parseQuery(this.query);
+        options = loaderUtils.getOptions(this);
     } catch (e) { }
 
     if (path.dirname(this.resource).includes(path.dirname(loaderPath))) {

--- a/json.js
+++ b/json.js
@@ -9,7 +9,7 @@ module.exports = function (indexContent) {
     let loaderPath = 'node_modules' + path.sep + '@kirschbaum-development' + path.sep + 'laravel-translations-loader' + path.sep + 'json.js';
 
     try {
-        options = loaderUtils.parseQuery(this.query);
+        options = loaderUtils.getOptions(this);
     } catch (e) { }
 
     if (path.dirname(this.resource).includes(path.dirname(loaderPath))) {


### PR DESCRIPTION
Option handling in Mix 6 for all and json-loaders (was already corrected for php)
Fixes issues #34 and #36 